### PR TITLE
fix: set macosx deployment target to avoid tons of go build warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 build:
 	cargo fmt
-	RUSTFLAGS='--print=native-static-libs -C strip=symbols' cargo build --release
+	MACOSX_DEPLOYMENT_TARGET=15.0 RUSTFLAGS='--print=native-static-libs -C strip=symbols' cargo build --release
 
 build-go-example: build
 	cp ./target/release/libmomento_protosocket_ffi.a ./examples/golang

--- a/examples/golang/main.go
+++ b/examples/golang/main.go
@@ -3,7 +3,7 @@ package main
 // Note: using LDFLAGS suggested by make build output
 
 /*
-#cgo LDFLAGS: ./libmomento_protosocket_ffi.a -ldl -framework Security -framework CoreFoundation -lc++ -liconv -lSystem -lc -lm
+#cgo LDFLAGS: ./libmomento_protosocket_ffi.a -ldl -framework Security -framework CoreFoundation -lc++ -liconv -lc -lm
 #include "./momento-protosocket-ffi.h"
 #include <string.h>
 */


### PR DESCRIPTION
Closes https://github.com/momentohq/momento-protosocket-ffi/issues/3

Previously, `go build main.go` and `go run main.go` would produce lots of `ld: warning: object file … was built for newer 'macOS' version (26.0) than being linked (15.0)` build warnings.

Setting `MACOSX_DEPLOYMENT_TARGET` when building the Rust FFI binary seems to resolve the issue.

Received only a single warning instead and removed duplicate library as a result:
`ld: warning: ignoring duplicate libraries: '-lSystem'`