### PR TITLE
fix: make sure to clean up all allocated resources

### DIFF
--- a/examples/golang/main.go
+++ b/examples/golang/main.go
@@ -42,7 +42,6 @@ func main() {
 	makeGetCall(cacheName, key)
 
 	C.destroy_protosocket_cache_client()
-
 }
 
 func convertGoStringToCBytes(string string) *C.Bytes {
@@ -109,7 +108,7 @@ func makeSetCall(cacheName string, key string, value string) {
 	}
 
 	// Free the C objects that were allocated
-	// C.free_response(response)
+	C.free_response(response)
 	C.free(unsafe.Pointer(cacheNameC))
 	C.free(unsafe.Pointer(keyC.data))
 	C.free(unsafe.Pointer(valueC.data))
@@ -162,7 +161,7 @@ func makeGetCall(cacheName string, key string) {
 		fmt.Printf("[ERROR] get error: %v\n", C.GoString(response.error_message))
 	}
 
-	// C.free_response(response)
+	C.free_response(response)
 	C.free(unsafe.Pointer(cacheNameC))
 	C.free(unsafe.Pointer(keyC.data))
 }


### PR DESCRIPTION
Work towards https://github.com/momentohq/momento-protosocket-ffi/issues/2

Calling `free_response()` no longer causes C errors, perhaps due to removal of problematic code in previous PR.

Used valgrind to confirm: "All heap blocks were freed -- no leaks are possible" though there are still invalid reads/writes we can revisit later once other repo setup work is complete.