### PR TITLE
ci: publish jobs should be gated by if released condition

### DIFF
--- a/.github/workflows/on-push-to-main.yml
+++ b/.github/workflows/on-push-to-main.yml
@@ -265,6 +265,7 @@ jobs:
   build-and-publish-ubuntu-x64:
     runs-on: ubuntu-24.04
     needs: [release-please]
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -327,6 +328,7 @@ jobs:
   build-and-publish-ubuntu-arm64:
     runs-on: ubuntu-24.04-arm
     needs: [release-please]
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -394,6 +396,7 @@ jobs:
   build-and-publish-macos-x64:
     runs-on: macos-15-intel
     needs: [release-please]
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -457,6 +460,7 @@ jobs:
   build-and-publish-macos-arm64:
     runs-on: macos-15
     needs: [release-please]
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
Work towards #5 

Add missing if condition to the `build-and-publish-*` jobs to ensure the binaries aren't published unless release-please created a release.

Push to main ran those steps but they resulted in an error instead of publishing anything:
```
{"message":"Not Found","request_id":"C410:27C3BA:109DC6:159300:68E97FD3","documentation_url":"https://docs.github.com/rest"}
```