### PR TITLE
chore: remove directory structure from released tar files, add pkg-config template file

### DIFF
--- a/.github/workflows/on-push-to-main.yml
+++ b/.github/workflows/on-push-to-main.yml
@@ -334,13 +334,14 @@ jobs:
         run: |
           echo "Version number: ${{ needs.release-please.outputs.version }}"
 
-      - name: Publish the C static library and header file
+      - name: Publish the C static library, header file, and pkg-config file
         run: |
           VERSION=${{ needs.release-please.outputs.version }}
           ARCHIVE_FILE="momento_protosocket_ffi-$VERSION.x86_64-linux.tar.gz"
           cp ./target/momento_protosocket_ffi.h ./momento_protosocket_ffi.h
           cp ./target/release/libmomento_protosocket_ffi.a ./momento_protosocket_ffi.a
-          tar -zcvf $ARCHIVE_FILE ./momento_protosocket_ffi.h ./momento_protosocket_ffi.a
+          cp ./examples/pkg-config-setup/momento_protosocket_ffi.pc ./momento_protosocket_ffi.pc
+          tar -zcvf $ARCHIVE_FILE ./momento_protosocket_ffi.h ./momento_protosocket_ffi.a ./momento_protosocket_ffi.pc
           AUTH="Authorization: token ${{ secrets.MOMENTO_MACHINE_USER_GITHUB_TOKEN }}"
           LATEST_RELEASE=$(curl -sH "$AUTH" https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/tags/v${VERSION})
           RELEASE_ID=$(echo $LATEST_RELEASE | jq -r .id)
@@ -402,13 +403,14 @@ jobs:
         run: |
           echo "Version number: ${{ needs.release-please.outputs.version }}"
 
-      - name: Publish the C static library and header file
+      - name: Publish the C static library, header file, and pkg-config file
         run: |
           VERSION=${{ needs.release-please.outputs.version }}
           ARCHIVE_FILE="momento_protosocket_ffi-$VERSION.arm64-linux.tar.gz"
           cp ./target/momento_protosocket_ffi.h ./momento_protosocket_ffi.h
           cp ./target/release/libmomento_protosocket_ffi.a ./momento_protosocket_ffi.a
-          tar -zcvf $ARCHIVE_FILE ./momento_protosocket_ffi.h ./momento_protosocket_ffi.a
+          cp ./examples/pkg-config-setup/momento_protosocket_ffi.pc ./momento_protosocket_ffi.pc
+          tar -zcvf $ARCHIVE_FILE ./momento_protosocket_ffi.h ./momento_protosocket_ffi.a ./momento_protosocket_ffi.pc
           AUTH="Authorization: token ${{ secrets.MOMENTO_MACHINE_USER_GITHUB_TOKEN }}"
           LATEST_RELEASE=$(curl -sH "$AUTH" https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/tags/v${VERSION})
           RELEASE_ID=$(echo $LATEST_RELEASE | jq -r .id)
@@ -466,13 +468,14 @@ jobs:
         run: |
           echo "Version number: ${{ needs.release-please.outputs.version }}"
 
-      - name: Publish the C static library and header file
+      - name: Publish the C static library, header file, and pkg-config file
         run: |
           VERSION=${{ needs.release-please.outputs.version }}
           ARCHIVE_FILE="momento_protosocket_ffi-$VERSION.x86_64-macos.tar.gz"
           cp ./target/momento_protosocket_ffi.h ./momento_protosocket_ffi.h
           cp ./target/release/libmomento_protosocket_ffi.a ./momento_protosocket_ffi.a
-          tar -zcvf $ARCHIVE_FILE ./momento_protosocket_ffi.h ./momento_protosocket_ffi.a
+          cp ./examples/pkg-config-setup/momento_protosocket_ffi.pc ./momento_protosocket_ffi.pc
+          tar -zcvf $ARCHIVE_FILE ./momento_protosocket_ffi.h ./momento_protosocket_ffi.a ./momento_protosocket_ffi.pc
           AUTH="Authorization: token ${{ secrets.MOMENTO_MACHINE_USER_GITHUB_TOKEN }}"
           LATEST_RELEASE=$(curl -sH "$AUTH" https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/tags/v${VERSION})
           RELEASE_ID=$(echo $LATEST_RELEASE | jq -r .id)
@@ -528,13 +531,14 @@ jobs:
         run: |
           echo "Version number: ${{ needs.release-please.outputs.version }}"
 
-      - name: Publish the C static library and header file
+      - name: Publish the C static library, header file, and pkg-config file
         run: |
           VERSION=${{ needs.release-please.outputs.version }}
           ARCHIVE_FILE="momento_protosocket_ffi-$VERSION.arm64-macos.tar.gz"
           cp ./target/momento_protosocket_ffi.h ./momento_protosocket_ffi.h
           cp ./target/release/libmomento_protosocket_ffi.a ./momento_protosocket_ffi.a
-          tar -zcvf $ARCHIVE_FILE ./momento_protosocket_ffi.h ./momento_protosocket_ffi.a
+          cp ./examples/pkg-config-setup/momento_protosocket_ffi.pc ./momento_protosocket_ffi.pc
+          tar -zcvf $ARCHIVE_FILE ./momento_protosocket_ffi.h ./momento_protosocket_ffi.a ./momento_protosocket_ffi.pc
           AUTH="Authorization: token ${{ secrets.MOMENTO_MACHINE_USER_GITHUB_TOKEN }}"
           LATEST_RELEASE=$(curl -sH "$AUTH" https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/tags/v${VERSION})
           RELEASE_ID=$(echo $LATEST_RELEASE | jq -r .id)


### PR DESCRIPTION
unzipped a release and discovered the tar file had kept the `target/release/...` directory structure, which is unnecessary

this PR should make it so that it's just the `.a` and `.h` files exist at the same level, alongside the pkg-config (`.pc`) template file too