### PR TITLE
chore: Switch the FFI to a string-based API key instead of an env var

### DIFF
--- a/examples/golang/main.go
+++ b/examples/golang/main.go
@@ -43,14 +43,13 @@ func main() {
 	connectionCount := C.ulong(1)
 	config := C.new_protosocket_client_configuration(timeoutMillis, connectionCount)
 
-	if os.Getenv("MOMENTO_API_KEY") == "" {
-		fmt.Printf("[ERROR] MOMENTO_API_KEY is not set\n")
-		os.Exit(1)
-	}
+	apiKey := os.Getenv("MOMENTO_API_KEY")
 
 	// Create FFI-compatible credential provider
-	envVarName := C.CString("MOMENTO_API_KEY")
-	creds := C.new_protosocket_credential_provider(envVarName)
+	cApiKey := C.CString(apiKey)
+	defer C.free(unsafe.Pointer(cApiKey))
+
+	creds := C.new_protosocket_credential_provider(cApiKey)
 
 	// Create the tokio runtime and the protosocket client under the hood
 	defaultTtlMillis := C.ulonglong(60 * 1000)

--- a/src/protosocket/cache_client.rs
+++ b/src/protosocket/cache_client.rs
@@ -52,12 +52,12 @@ pub extern "C" fn init_protosocket_cache_client(
         .az_id(None)
         .build();
 
-    let env_var_name = unsafe {
-        std::ffi::CStr::from_ptr(credential_provider.env_var_name)
+    let api_key = unsafe {
+        std::ffi::CStr::from_ptr(credential_provider.api_key)
             .to_string_lossy()
             .into_owned()
     };
-    let creds = CredentialProvider::from_env_var(env_var_name).expect("auth token should be valid");
+    let creds = CredentialProvider::from_string(api_key).expect("auth token should be valid");
 
     let client = RUNTIME.block_on(async {
         ProtosocketCacheClient::builder()

--- a/src/protosocket/configuration.rs
+++ b/src/protosocket/configuration.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use libc::c_char;
 
 #[derive(PartialEq, Eq, Clone, Debug)]
@@ -23,14 +24,22 @@ impl ProtosocketClientConfiguration {
 #[derive(PartialEq, Eq, Clone)]
 #[repr(C)]
 pub struct ProtosocketCredentialProvider {
-    pub(crate) env_var_name: *const c_char,
+    pub(crate) api_key: *const c_char,
+}
+
+impl fmt::Debug for ProtosocketCredentialProvider {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ProtosocketCredentialProvider")
+            .field("api_key", &"<redacted>")
+            .finish()
+    }
 }
 
 impl ProtosocketCredentialProvider {
     #[unsafe(no_mangle)]
     pub extern "C" fn new_protosocket_credential_provider(
-        env_var_name: *const c_char,
+        api_key: *const c_char,
     ) -> ProtosocketCredentialProvider {
-        ProtosocketCredentialProvider { env_var_name }
+        ProtosocketCredentialProvider { api_key }
     }
 }


### PR DESCRIPTION
closes issue #27